### PR TITLE
Add scroll to top functionality when filtering list items

### DIFF
--- a/Kneuron.js
+++ b/Kneuron.js
@@ -284,6 +284,7 @@ function addTablesFilter() {
         searchInput.style.height = '35px';
         searchInput.id = 'incremental-filter';
         searchInput.addEventListener('input', (e) => {
+            document.querySelector('.left-toolbox').scrollTop = 0;
             const hasMatches = filterListItems(e.target.value);
             searchInput.style.backgroundColor = hasMatches ? 'white' : ERROR_COLOR;
         });


### PR DESCRIPTION
Means you can see the first few elements.
I thought it wasn't working properly when I get to the third letter it appeared that it didn't find any tables